### PR TITLE
Clear customer address registry on retrieving entities

### DIFF
--- a/Model/AsyncCustomerAddressManagement.php
+++ b/Model/AsyncCustomerAddressManagement.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CommonAsyncEvents\Model;
+
+use Magento\Customer\Api\AddressRepositoryInterface as CustomerAddressRepositoryInterface;
+use Magento\Customer\Api\Data\AddressInterface as CustomerAddressInterface;
+use Magento\Customer\Model\AddressRegistry as CustomerAddressRegistry;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class AsyncCustomerAddressManagement
+{
+    private CustomerAddressRepositoryInterface $customerAddressRepository;
+    private CustomerAddressRegistry $customerAddressRegistry;
+
+    public function __construct(
+        CustomerAddressRepositoryInterface $customerAddressRepository,
+        CustomerAddressRegistry $customerAddressRegistry
+    ) {
+        $this->customerAddressRepository = $customerAddressRepository;
+        $this->customerAddressRegistry = $customerAddressRegistry;
+    }
+
+    /**
+     * The CustomerAddressRepository uses a CustomerAddressRegistry which will cache entities on load. If the updates
+     * happen in a different thread, there is a possibility that stale data is returned.
+     * However, we still want to use the repository instead of using the resource model to preserve modifications
+     * added by plugins.
+     *
+     * Therefore, manually removing the entity from the registry should guarantee that it is always loaded from the
+     * database.
+     *
+     * @param int $addressId
+     * @return \Magento\Customer\Api\Data\AddressInterface
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $addressId): CustomerAddressInterface
+    {
+        $this->customerAddressRegistry->remove($addressId);
+        return $this->customerAddressRepository->getById($addressId);
+    }
+}

--- a/etc/async_events.xml
+++ b/etc/async_events.xml
@@ -8,10 +8,10 @@
         <service class="MageOS\CommonAsyncEvents\Model\AsyncCustomerManagement" method="getById"/>
     </async_event>
     <async_event name="customer.address.created">
-        <service class="Magento\Customer\Api\AddressRepositoryInterface" method="getById"/>
+        <service class="MageOS\CommonAsyncEvents\Model\AsyncCustomerAddressManagement" method="getById"/>
     </async_event>
     <async_event name="customer.address.updated">
-        <service class="Magento\Customer\Api\AddressRepositoryInterface" method="getById"/>
+        <service class="MageOS\CommonAsyncEvents\Model\AsyncCustomerAddressManagement" method="getById"/>
     </async_event>
     <async_event name="sales.order.created">
         <service class="Magento\Sales\Api\OrderRepositoryInterface" method="get"/>


### PR DESCRIPTION
The CustomerAddressRepository uses a CustomerAddressRegistry which will cache entities on load. If the updates happen in a different thread, there is a possibility that stale data is returned.
However, we still want to use the repository instead of using the resource model to preserve modifications added by plugins.

Therefore, manually removing the entity from the registry should guarantee that it is always loaded from the database.

This is the same solution as used for the customer entity.