### PR TITLE
Fix(sales): Fix observers for sales order and shipment

### DIFF
--- a/Observer/SalesOrderCreditmemoSaveAfterObserver.php
+++ b/Observer/SalesOrderCreditmemoSaveAfterObserver.php
@@ -25,7 +25,7 @@ class SalesOrderCreditmemoSaveAfterObserver implements ObserverInterface
         if ($this->isCreditmemoCreated($creditmemo)) {
             $this->publisherService->publish(
                 'sales.creditmemo.created',
-                ['id' => $creditmemo->getIncrementId()]
+                ['id' => $creditmemo->getId()]
             );
         }
     }

--- a/Observer/SalesOrderInvoiceSaveAfterObserver.php
+++ b/Observer/SalesOrderInvoiceSaveAfterObserver.php
@@ -22,7 +22,7 @@ class SalesOrderInvoiceSaveAfterObserver implements ObserverInterface
     {
         /** @var Invoice $invoice */
         $invoice = $observer->getEvent()->getData('invoice');
-        $arguments = ['id' => $invoice->getIncrementId()];
+        $arguments = ['id' => $invoice->getId()];
 
         if ($this->isInvoiceCreated($invoice)) {
             $this->publisherService->publish(

--- a/Observer/SalesOrderSaveAfterObserver.php
+++ b/Observer/SalesOrderSaveAfterObserver.php
@@ -22,7 +22,7 @@ class SalesOrderSaveAfterObserver implements ObserverInterface
     {
         /** @var Order $order */
         $order = $observer->getEvent()->getData('order');
-        $arguments = ['id' => $order->getIncrementId()];
+        $arguments = ['id' => $order->getId()];
 
         if ($this->isOrderNew($order)) {
             $this->publisherService->publish(

--- a/Observer/SalesOrderShipmentSaveAfterObserver.php
+++ b/Observer/SalesOrderShipmentSaveAfterObserver.php
@@ -25,7 +25,7 @@ class SalesOrderShipmentSaveAfterObserver implements ObserverInterface
         if ($this->isShipmentNew($shipment)) {
             $this->publisherService->publish(
                 'sales.shipment.created',
-                ['id' => $shipment->getIncrementId()]
+                ['id' => $shipment->getId()]
             );
         }
         if ($this->isOrderFullyShipped($shipment)) {


### PR DESCRIPTION
In both cases the increment_id was written to the queue, although the entity_id was needed for the supplied consumers.