### PR TITLE
Fixed typo in order status "canceled"

### DIFF
--- a/Observer/SalesOrderSaveAfterObserver.php
+++ b/Observer/SalesOrderSaveAfterObserver.php
@@ -88,16 +88,16 @@ class SalesOrderSaveAfterObserver implements ObserverInterface
 
     private function isOrderHolded(Order $order): bool
     {
-        return ($order->getState() == 'holded') && $order->getOrigData('state') != 'holded';
+        return ($order->getState() == Order::STATE_HOLDED) && $order->getOrigData('state') != Order::STATE_HOLDED;
     }
 
     private function isOrderUnholded(Order $order): bool
     {
-        return ($order->getState() != 'holded') && $order->getOrigData('state') == 'holded';
+        return ($order->getState() != Order::STATE_HOLDED) && $order->getOrigData('state') == Order::STATE_HOLDED;
     }
 
     private function isOrderCancelled(Order $order): bool
     {
-        return ($order->isCanceled()) && $order->getOrigData('state') != Magento\Sales\Model\Order::STATE_CANCELED;
+        return ($order->isCanceled()) && $order->getOrigData('state') != Order::STATE_CANCELED;
     }
 }

--- a/Observer/SalesOrderSaveAfterObserver.php
+++ b/Observer/SalesOrderSaveAfterObserver.php
@@ -98,6 +98,6 @@ class SalesOrderSaveAfterObserver implements ObserverInterface
 
     private function isOrderCancelled(Order $order): bool
     {
-        return ($order->isCanceled()) && $order->getOrigData('state') != 'cancelled';
+        return ($order->isCanceled()) && $order->getOrigData('state') != 'canceled';
     }
 }

--- a/Observer/SalesOrderSaveAfterObserver.php
+++ b/Observer/SalesOrderSaveAfterObserver.php
@@ -98,6 +98,6 @@ class SalesOrderSaveAfterObserver implements ObserverInterface
 
     private function isOrderCancelled(Order $order): bool
     {
-        return ($order->isCanceled()) && $order->getOrigData('state') != 'canceled';
+        return ($order->isCanceled()) && $order->getOrigData('state') != Magento\Sales\Model\Order::STATE_CANCELED;
     }
 }


### PR DESCRIPTION
For a canceled order, an event was sent every time the order was saved because of a typo in the status "canceled"