### PR TITLE
Change customer save before observer to listen for "customer_save_before" event

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -5,7 +5,7 @@
         <observer name="mageos_common_async_events_customer_save_after"
                   instance="MageOS\CommonAsyncEvents\Observer\CustomerSaveAfterObserver"/>
     </event>
-    <event name="customer_save_commit_before">
+    <event name="customer_save_before">
         <observer name="mageos_common_async_events_customer_save_before"
                   instance="MageOS\CommonAsyncEvents\Observer\CustomerSaveBeforeObserver"/>
     </event>


### PR DESCRIPTION
Fixes #23 

The current implementation is listening for the "customer_save_commit_before" event, but this event does not exist in the core Magento implementation. Instead, it should be listening to the "customer_save_before" event.
This will ensure that customers with changed data get flagged as having been updated properly.