### PR TITLE
Refactor getEventIdentifier method to remove parameter

### DIFF
--- a/Observer/CustomerLoginObserver.php
+++ b/Observer/CustomerLoginObserver.php
@@ -24,7 +24,7 @@ class CustomerLoginObserver implements ObserverInterface
         /** @var Customer $customer */
         $customer = $observer->getEvent()->getData('customer');
 
-        $eventIdentifier = $this->getEventIdentifier($customer);
+        $eventIdentifier = $this->getEventIdentifier();
         if ($eventIdentifier === null) {
             return;
         }
@@ -36,7 +36,7 @@ class CustomerLoginObserver implements ObserverInterface
         );
     }
 
-    private function getEventIdentifier(Customer $customer): ?string
+    private function getEventIdentifier(): ?string
     {
         return 'customer.login';
     }


### PR DESCRIPTION
In https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Integration/Model/CustomerTokenService.php#L73 Magento triggers this event with the data model instead of the regular customer model.

This breaks the api endpoint to create tokens.

Will also create a MR on Magento, story for another day